### PR TITLE
Remove warning message about contact phone numbers in ContentView

### DIFF
--- a/saracroche/ContentView.swift
+++ b/saracroche/ContentView.swift
@@ -89,11 +89,6 @@ struct ContentView: View {
       )
       .font(.footnote)
       .frame(maxWidth: .infinity, alignment: .leading)
-
-      Text("⚠ Les numéros de téléphone présents dans vos contacts ne seront pas bloqués.")
-        .font(.footnote)
-        .padding(.top)
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
     .padding()
     .onAppear {


### PR DESCRIPTION
Eliminate the warning message regarding contact phone numbers in the ContentView to improve user experience.