### PR TITLE
Update blocked numbers threshold for user defaults saving

### DIFF
--- a/blocker/CallDirectoryHandler.swift
+++ b/blocker/CallDirectoryHandler.swift
@@ -34,7 +34,7 @@ class CallDirectoryHandler: CXCallDirectoryProvider {
             
             blockedNumbers += 1
             
-            if blockedNumbers % 100000 == 0 {
+            if blockedNumbers % 1000 == 0 {
               sharedUserDefaults?.set(blockedNumbers, forKey: "blockedNumbers")
             }
           }


### PR DESCRIPTION
Adjust the threshold for saving blocked numbers to user defaults from every 100,000 to every 1,000.