### PR TITLE
Remplace link to remove the block list by a button

### DIFF
--- a/saracroche/ContentView.swift
+++ b/saracroche/ContentView.swift
@@ -117,13 +117,12 @@ struct ContentView: View {
             .cornerRadius(8)
           }
 
-          Text("Supprimer la liste de blocage")
+          Button("Supprimer la liste de blocage") {
+            removeBlockerList()
+          }
           .foregroundColor(.blue)
           .underline()
           .padding()
-          .onTapGesture {
-            removeBlockerList()
-          }
         } else {
           Button("Installer la liste de blocage") {
             reloadBlockerListExtension()


### PR DESCRIPTION
This pull request includes a change to the `ContentView.swift` file to improve the user interface and code readability by replacing a `Text` element with a `Button` element for the "Supprimer la liste de blocage" action.

UI Improvement:

* Changed the `Text` element to a `Button` element for the "Supprimer la liste de blocage" action to improve user interaction and consistency.