### PR TITLE
Fix App Store rating link functionality

### DIFF
--- a/saracroche/SaracrocheView.swift
+++ b/saracroche/SaracrocheView.swift
@@ -1,5 +1,4 @@
 import StoreKit
-import SwiftUI
 
 struct FullWidthButtonStyle: ButtonStyle {
   var backgroundColor: Color
@@ -31,7 +30,6 @@ extension ButtonStyle where Self == FullWidthButtonStyle {
 struct SaracrocheView: View {
   @StateObject private var viewModel = SaracrocheViewModel()
   @State private var showDeleteConfirmation = false
-  @Environment(\.requestReview) var requestReview
 
   var body: some View {
     TabView {
@@ -43,14 +41,13 @@ struct SaracrocheView: View {
         .tabItem {
           Label("Signaler", systemImage: "exclamationmark.bubble.fill")
         }
-      HelpNavigationView(requestReview: { requestReview() })
+      HelpNavigationView()
         .tabItem {
           Label("Aide", systemImage: "questionmark.circle.fill")
         }
       SettingsNavigationView(
         viewModel: viewModel,
-        showDeleteConfirmation: $showDeleteConfirmation,
-        requestReview: { requestReview() }
+        showDeleteConfirmation: $showDeleteConfirmation
       )
       .tabItem {
         Label("Réglages", systemImage: "gearshape.fill")

--- a/saracroche/Views/HelpNavigationView.swift
+++ b/saracroche/Views/HelpNavigationView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct HelpNavigationView: View {
-  var requestReview: () -> Void
   var body: some View {
     NavigationStack {
       ScrollView {
@@ -129,7 +128,12 @@ struct HelpNavigationView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             Button {
-              requestReview()
+              if let url = URL(
+                string:
+                  "https://apps.apple.com/app/id6743679292?action=write-review"
+              ) {
+                UIApplication.shared.open(url)
+              }
             } label: {
               HStack {
                 Image(systemName: "star.fill")

--- a/saracroche/Views/SettingsNavigationView.swift
+++ b/saracroche/Views/SettingsNavigationView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct SettingsNavigationView: View {
   @ObservedObject var viewModel: SaracrocheViewModel
   @Binding var showDeleteConfirmation: Bool
-  var requestReview: () -> Void
   var body: some View {
     NavigationView {
       Form {
@@ -78,7 +77,12 @@ struct SettingsNavigationView: View {
 
         Section(header: Text("Application")) {
           Button {
-            requestReview()
+            if let url = URL(
+              string:
+                "https://apps.apple.com/app/id6743679292?action=write-review"
+            ) {
+              UIApplication.shared.open(url)
+            }
           } label: {
             Label("Noter l'application", systemImage: "star.fill")
           }


### PR DESCRIPTION
Refactor the Help and Settings navigation views to directly open the App Store review URL, resolving the issue with the non-functional rating link.

Fixes #13