### PR TITLE
Disable idle timer during long-running tasks

### DIFF
--- a/saracroche/SaracrocheViewModel.swift
+++ b/saracroche/SaracrocheViewModel.swift
@@ -133,6 +133,7 @@ class SaracrocheViewModel: ObservableObject {
   }
 
   func updateBlockerList() {
+    UIApplication.shared.isIdleTimerDisabled = true
     sharedUserDefaults?.set("update", forKey: "blockerActionState")
     sharedUserDefaults?.set(
       countAllBlockedNumbers(),
@@ -167,6 +168,7 @@ class SaracrocheViewModel: ObservableObject {
         }
       } else {
         sharedUserDefaults?.set("finish", forKey: "blockerActionState")
+        UIApplication.shared.isIdleTimerDisabled = false
       }
     }
 
@@ -184,11 +186,13 @@ class SaracrocheViewModel: ObservableObject {
   }
 
   func cancelUpdateBlockerAction() {
+    UIApplication.shared.isIdleTimerDisabled = false
     sharedUserDefaults?.set("", forKey: "blockerActionState")
     updateBlockerState()
   }
 
   func removeBlockerList() {
+    UIApplication.shared.isIdleTimerDisabled = true
     sharedUserDefaults?.set("delete", forKey: "blockerActionState")
     sharedUserDefaults?.set(0, forKey: "blockedNumbers")
 
@@ -202,16 +206,19 @@ class SaracrocheViewModel: ObservableObject {
           self.blockerExtensionStatus = .error
         }
         self.sharedUserDefaults?.set("", forKey: "blockerActionState")
+        UIApplication.shared.isIdleTimerDisabled = false
       }
     }
   }
 
   func cancelRemoveBlockerAction() {
+    UIApplication.shared.isIdleTimerDisabled = false
     sharedUserDefaults?.set("", forKey: "blockerActionState")
     updateBlockerState()
   }
 
   func markBlockerActionFinished() {
+    UIApplication.shared.isIdleTimerDisabled = false
     sharedUserDefaults?.set("", forKey: "blockerActionState")
     updateBlockerState()
   }


### PR DESCRIPTION
Disable the idle timer when updating or removing the blocker list to prevent the phone from going into the background. Re-enable the idle timer once the task is completed or canceled.

Fixes #16