### PR TITLE
Fix blocker extension status check for non-nothing states

### DIFF
--- a/saracroche/SaracrocheViewModel.swift
+++ b/saracroche/SaracrocheViewModel.swift
@@ -160,6 +160,10 @@ class SaracrocheViewModel: ObservableObject {
   }
 
   func checkBlockerExtensionStatus() {
+    if self.blockerActionState !== .nothing {
+      return self.blockerExtensionStatus = .unknown
+    }
+    
     let manager = CXCallDirectoryManager.sharedInstance
 
     manager.getEnabledStatusForExtension(


### PR DESCRIPTION
This pull request introduces a small but important change to the `SaracrocheViewModel` class to improve the handling of `blockerExtensionStatus`. Specifically, it adds a conditional check to ensure that the `blockerActionState` is `.nothing` before proceeding, and sets the `blockerExtensionStatus` to `.unknown` if the condition is not met.