### PR TITLE
Reduce chunk size for phone number processing from 50,000 to 10,000

### DIFF
--- a/saracroche/SaracrocheViewModel.swift
+++ b/saracroche/SaracrocheViewModel.swift
@@ -130,7 +130,7 @@ class SaracrocheViewModel: ObservableObject {
         let pattern = patternsToProcess.removeFirst()
         let numbersListForPattern = generatePhoneNumbers(prefix: pattern)
 
-        let chunkSize = 50_000
+        let chunkSize = 10_000
         var chunkIndex = 0
 
         func processNextChunk() {


### PR DESCRIPTION
This pull request includes a single change to the `SaracrocheViewModel` class in the `saracroche/SaracrocheViewModel.swift` file. The change reduces the `chunkSize` variable from 50,000 to 10,000, likely to optimize memory usage or processing performance.