### PR TITLE
Refactor PrefixGenerator for improved CSV and JSON handling

### DIFF
--- a/generateJson.php
+++ b/generateJson.php
@@ -1,119 +1,110 @@
 <?php
+declare(strict_types=1);
 
-$csvFile = 'MAJNUM.csv';
-$jsonFile = 'saracroche/prefixes.json';
+class PrefixGenerator
+{
+    private string $csvFile = 'MAJNUM.csv';
+    private string $csvUrl = 'https://extranet.arcep.fr/uploads/MAJNUM.csv';
+    private string $jsonFile = 'saracroche/prefixes.json';
+    private array $blockedOperators = [
+        'DVSC', 'LGC', 'ZETE', 'OXIL', 'BJTP', 'UBIC', 'OPEN', 'KAVE', 'SPAR',
+    ];
+    private array $arcepPrefixes = [
+        '33162', '33163', '33270', '33271', '33377', '33378',
+        '33424', '33425', '33568', '33569', '33948', '33949',
+        '339475', '339476', '339477', '339478', '339479',
+    ];
+    private array $output = [];
 
-// Définir ici les opérateurs à inclure. Laisser vide pour tout inclure.
-$blockedOperators = [
-  'DVSC',
-  'LGC',
-  'ZETE',
-  'OXIL',
-  'BJTP',
-  'UBIC',
-  'OPEN',
-  'KAVE',
-  'SPAR',
-];
-
-$handle = fopen($csvFile, 'r');
-$output = [];
-
-// Ajouter les préfixes Arcep
-$arcepPrefixes = [
-  '33162',
-  '33163',
-  '33270',
-  '33271',
-  '33377',
-  '33378',
-  '33424',
-  '33425',
-  '33568',
-  '33569',
-  '33948',
-  '33949',
-  '339475',
-  '339476',
-  '339477',
-  '339478',
-  '339479',
-];
-
-foreach ($arcepPrefixes as $prefix) {
-  $nbDigitsToFill = 11 - strlen($prefix);
-  $pattern = $prefix . str_repeat('#', $nbDigitsToFill);
-  $output[] = [
-    'operator' => 'ARCEP',
-    'prefix' => $pattern
-  ];
-}
-
-if ($handle !== false) {
-  $headers = fgetcsv($handle, 1000, ';', '"', "\n"); // Lire l'en-tête
-  $headers = array_map(function ($h) {
-    return mb_convert_encoding($h, 'UTF-8', 'ISO-8859-1');
-  }, $headers);
-
-  while (($data = fgetcsv($handle, 1000, ';', '"', "\n")) !== false) {
-    // Convertir chaque champ en UTF-8
-    $data = array_map(function ($d) {
-      return mb_convert_encoding($d, 'UTF-8', 'ISO-8859-1');
-    }, $data);
-    $row = array_combine($headers, $data);
-
-    $ezabpqm = $row['EZABPQM'];
-    $operator = $row['Mnémo'];
-
-    if (in_array($operator, $blockedOperators) && preg_match('/^\d+$/', $ezabpqm)) {
-      // Retirer le premier 0 si présent
-      $ezabpqm = ltrim($ezabpqm, '0');
-
-      // Créer le préfixe E.164 : +33 + EZABPQM
-      $numericPrefix = '33' . $ezabpqm;
-
-      echo "🔍 Préfixe trouvé : $numericPrefix pour l'opérateur $operator\n";
-
-      // Vérifier qu'un préfixe ne commence par un préfixe déjà existant dans la liste $arcepPrefixes
-      $isPrefixBlocked = false;
-      foreach ($arcepPrefixes as $arcepPrefix) {
-        if (strpos($numericPrefix, $arcepPrefix) === 0) {
-          echo "❌ Préfixe $numericPrefix est déjà bloqué par le préfixe ARCEP : $arcepPrefix\n";
-          $isPrefixBlocked = true;
-          break;
-        }
-      }
-
-      if ($isPrefixBlocked) {
-        continue; // Passer à l'itération suivante si le préfixe est bloqué
-      }
-
-      $nbDigitsToFill = 11 - strlen($numericPrefix); // max E.164: 11 digits
-      $pattern = $numericPrefix . str_repeat('#', $nbDigitsToFill);
-
-      $output[] = [
-        'operator' => $operator,
-        'prefix' => $pattern
-      ];
+    public function __construct()
+    {
+        $this->downloadCsv();
+        $this->addArcepPrefixes();
+        $this->processCsv();
+        $this->writeJson();
+        $this->countTotalNumbers();
     }
-  }
 
-  fclose($handle);
+    public function downloadCsv(): void
+    {
+        echo "⬇️ Téléchargement du fichier CSV depuis {$this->csvUrl}...\n";
+        $csvData = file_get_contents($this->csvUrl);
+        if ($csvData === false) {
+            die("❌ Erreur lors du téléchargement du fichier CSV.\n");
+        }
+        file_put_contents($this->csvFile, $csvData);
+        echo "✅ Fichier CSV téléchargé avec succès.\n";
+    }
+
+    public function addArcepPrefixes(): void
+    {
+        foreach ($this->arcepPrefixes as $prefix) {
+            $nbDigitsToFill = 11 - strlen($prefix);
+            $pattern = $prefix . str_repeat('#', $nbDigitsToFill);
+            $this->output[] = [
+                'operator' => 'ARCEP',
+                'prefix' => $pattern
+            ];
+        }
+    }
+
+    public function processCsv(): void
+    {
+        $handle = fopen($this->csvFile, 'r');
+        if ($handle === false) return;
+        $headers = fgetcsv($handle, 1000, ';', '"', "\n");
+        $headers = array_map(function ($h) {
+            return mb_convert_encoding($h, 'UTF-8', 'ISO-8859-1');
+        }, $headers);
+        while (($data = fgetcsv($handle, 1000, ';', '"', "\n")) !== false) {
+            $data = array_map(function ($d) {
+                return mb_convert_encoding($d, 'UTF-8', 'ISO-8859-1');
+            }, $data);
+            $row = array_combine($headers, $data);
+            $ezabpqm = $row['EZABPQM'];
+            $operator = $row['Mnémo'];
+            if (in_array($operator, $this->blockedOperators) && preg_match('/^\d+$/', $ezabpqm)) {
+                $ezabpqm = ltrim($ezabpqm, '0');
+                $numericPrefix = '33' . $ezabpqm;
+                echo "🔍 Préfixe trouvé : $numericPrefix pour l'opérateur $operator\n";
+                $isPrefixBlocked = false;
+                foreach ($this->arcepPrefixes as $arcepPrefix) {
+                    if (strpos($numericPrefix, $arcepPrefix) === 0) {
+                        echo "❌ Préfixe $numericPrefix est déjà bloqué par le préfixe ARCEP : $arcepPrefix\n";
+                        $isPrefixBlocked = true;
+                        break;
+                    }
+                }
+                if ($isPrefixBlocked) continue;
+                $nbDigitsToFill = 11 - strlen($numericPrefix);
+                $pattern = $numericPrefix . str_repeat('#', $nbDigitsToFill);
+                $this->output[] = [
+                    'operator' => $operator,
+                    'prefix' => $pattern
+                ];
+            }
+        }
+        fclose($handle);
+    }
+
+    public function writeJson(): void
+    {
+        file_put_contents($this->jsonFile, json_encode($this->output, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        echo "✅ Fichier JSON généré avec succès !\n";
+    }
+
+    public function countTotalNumbers(): int
+    {
+        $totalNumbers = 0;
+        foreach ($this->output as $entry) {
+            $prefix = $entry['prefix'];
+            $numHashes = substr_count($prefix, '#');
+            $possibleNumbers = pow(10, $numHashes);
+            $totalNumbers += $possibleNumbers;
+        }
+        echo "🟰 Nombre total de numéros possibles pour tous les préfixes : {$totalNumbers}\n";
+        return $totalNumbers;
+    }
 }
 
-// Écriture JSON
-file_put_contents($jsonFile, json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
-
-// Calculer le nombre total de numéros possibles pour chaque préfixe dans $output
-$totalNumbers = 0;
-
-foreach ($output as $entry) {
-  $prefix = $entry['prefix'];
-  $numHashes = substr_count($prefix, '#');
-  $possibleNumbers = pow(10, $numHashes);
-  $totalNumbers += $possibleNumbers;
-}
-
-echo "✅ Fichier JSON généré avec succès !\n";
-echo "🟰 Nombre total de numéros possibles pour tous les préfixes : {$totalNumbers}\n";
-echo "🗂️ Fichier JSON généré : $jsonFile\n";
+new PrefixGenerator();


### PR DESCRIPTION
This pull request refactors the `generateJson.php` script into a structured object-oriented approach by introducing a `PrefixGenerator` class. The changes improve code organization, readability, and maintainability while preserving the original functionality. Below are the key changes grouped by theme:

### Refactoring and Code Organization
* Converted the procedural script into a `PrefixGenerator` class with private properties and methods to encapsulate functionality. The class includes methods such as `downloadCsv`, `addArcepPrefixes`, `processCsv`, `writeJson`, and `countTotalNumbers` for modular operations.
* Replaced global variables with private class properties like `$csvFile`, `$csvUrl`, `$jsonFile`, `$blockedOperators`, `$arcepPrefixes`, and `$output`.

### New Features
* Added a `downloadCsv` method to fetch the CSV file from a specified URL (`$csvUrl`) and save it locally, providing better automation and flexibility.
* Introduced a `countTotalNumbers` method to calculate and display the total number of possible phone numbers based on the prefixes generated.

### Code Simplification and Readability
* Simplified the handling of CSV data by centralizing encoding conversion and header mapping within the `processCsv` method. 