### PR TITLE
Refactor SaracrocheViewModel and update HomeNavigationView for status checks

### DIFF
--- a/saracroche/Views/HomeNavigationView.swift
+++ b/saracroche/Views/HomeNavigationView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeNavigationView: View {
   @ObservedObject var viewModel: SaracrocheViewModel
+  @Environment(\.scenePhase) private var scenePhase
   var body: some View {
     NavigationView {
       VStack {
@@ -295,6 +296,14 @@ struct HomeNavigationView: View {
         Spacer()
       }
       .navigationTitle("Saracroche")
+      .onAppear {
+        viewModel.checkBlockerExtensionStatus()
+      }
+      .onChange(of: scenePhase) { newPhase in
+        if newPhase == .active {
+          viewModel.checkBlockerExtensionStatus()
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request refactors the `SaracrocheViewModel` class to simplify its lifecycle management and improve the handling of the blocker extension status. It also updates the `HomeNavigationView` to ensure the blocker extension status is checked when the view appears or becomes active.

### Refactoring `SaracrocheViewModel`

* Removed the `init` and `deinit` methods, along with the associated timer management methods (`startTimerBlockerExtensionStatus`, `stopStatusBlockerExtensionStatus`, `startUpdateTimer`, `stopUpdateTimer`). This eliminates the need for timer-based lifecycle management. [[1]](diffhunk://#diff-6aa93a4982c7e79020c0ed1935a28bb200407d22a321aa1e1af4374cb89802a6L36-R46) [[2]](diffhunk://#diff-6aa93a4982c7e79020c0ed1935a28bb200407d22a321aa1e1af4374cb89802a6L279-L302)
* Replaced calls to `updateBlockerState()` with `checkBlockerExtensionStatus()` in several methods to ensure consistent handling of the blocker extension status. [[1]](diffhunk://#diff-6aa93a4982c7e79020c0ed1935a28bb200407d22a321aa1e1af4374cb89802a6L188-R187) [[2]](diffhunk://#diff-6aa93a4982c7e79020c0ed1935a28bb200407d22a321aa1e1af4374cb89802a6R200-R214)
* Added calls to `checkBlockerExtensionStatus()` and `updateBlockerState()` at appropriate points in the `updateBlockerList` and `removeBlockerList` workflows to maintain proper state updates. [[1]](diffhunk://#diff-6aa93a4982c7e79020c0ed1935a28bb200407d22a321aa1e1af4374cb89802a6R108-R112) [[2]](diffhunk://#diff-6aa93a4982c7e79020c0ed1935a28bb200407d22a321aa1e1af4374cb89802a6R124-R125) [[3]](diffhunk://#diff-6aa93a4982c7e79020c0ed1935a28bb200407d22a321aa1e1af4374cb89802a6R159)

### Improvements to error handling

* Added `TODO` comments in error handling blocks for `checkBlockerExtensionStatus()` calls, signaling areas where error handling logic needs to be implemented. [[1]](diffhunk://#diff-6aa93a4982c7e79020c0ed1935a28bb200407d22a321aa1e1af4374cb89802a6R143) [[2]](diffhunk://#diff-6aa93a4982c7e79020c0ed1935a28bb200407d22a321aa1e1af4374cb89802a6R168)

### Updates to `HomeNavigationView`

* Introduced the `scenePhase` environment property to monitor app lifecycle events.
* Ensured `checkBlockerExtensionStatus()` is called when the view appears (`onAppear`) or when the app becomes active (`onChange` of `scenePhase`).