### PR TITLE
Fix CallDirectoryHandler for improved action handling

### DIFF
--- a/blocker/CallDirectoryHandler.swift
+++ b/blocker/CallDirectoryHandler.swift
@@ -11,18 +11,16 @@ class CallDirectoryHandler: CXCallDirectoryProvider {
     context.delegate = self
 
     if context.isIncremental {
-      print("Incremental update requested")
-
-      let action = sharedUserDefaults?.string(forKey: "action")
+      let action = sharedUserDefaults?.string(forKey: "action") ?? ""
 
       if action == "resetNumbersList" {
         handleResetNumbersList(to: context)
       } else if action == "addNumbersList" {
         handleAddNumbersList(to: context)
       }
-      
-      sharedUserDefaults?.set("", forKey: "action")
-    }
+    } else {
+      context.addBlockingEntry(withNextSequentialPhoneNumber: 1_800_555_5555)
+    } 
 
     context.completeRequest()
   }
@@ -35,6 +33,7 @@ class CallDirectoryHandler: CXCallDirectoryProvider {
     context.removeAllIdentificationEntries()
 
     sharedUserDefaults?.set(0, forKey: "blockedNumbers")
+    sharedUserDefaults?.set("", forKey: "action")
   }
 
   private func handleAddNumbersList(to context: CXCallDirectoryExtensionContext)
@@ -55,6 +54,7 @@ class CallDirectoryHandler: CXCallDirectoryProvider {
     }
 
     sharedUserDefaults?.set(blockedNumbers, forKey: "blockedNumbers")
+    sharedUserDefaults?.set("", forKey: "action")
   }
 }
 


### PR DESCRIPTION
This pull request refactors the `CallDirectoryHandler` class in `blocker/CallDirectoryHandler.swift` to streamline the handling of user defaults and improve the logic for managing call directory updates. The most important changes include consolidating the reset of the `action` key in user defaults, simplifying the incremental update logic, and adding a default blocking entry for non-incremental updates.

### Improvements to user defaults handling:
* Consolidated the reset of the `action` key in `sharedUserDefaults` by adding it to the `handleResetNumbersList` and `handleAddNumbersList` methods, ensuring consistent cleanup after processing actions. [[1]](diffhunk://#diff-c90d3d39d9106d8000452325efcebed9266c979e83c658445530cf494c63f6cdR36) [[2]](diffhunk://#diff-c90d3d39d9106d8000452325efcebed9266c979e83c658445530cf494c63f6cdR57)

### Incremental update logic:
* Simplified the `isIncremental` branch by removing unnecessary debug print statements and ensuring the `action` key defaults to an empty string if not set.

### Non-incremental updates:
* Added a default blocking entry (`1_800_555_5555`) for non-incremental updates to ensure the call directory is not empty.