### PR TITLE
Fix update blocklist version during update and remove actions

### DIFF
--- a/saracroche/Services/CallDirectoryService.swift
+++ b/saracroche/Services/CallDirectoryService.swift
@@ -73,6 +73,11 @@ class CallDirectoryService {
     UIApplication.shared.isIdleTimerDisabled = true
 
     var patternsToProcess = phoneNumberService.loadPhoneNumberPatterns()
+    
+    sharedUserDefaults.setBlocklistVersion(
+      AppConstants.currentBlocklistVersion
+    )
+    
     sharedUserDefaults.setTotalBlockedNumbers(
       phoneNumberService.countAllBlockedNumbers()
     )
@@ -121,9 +126,6 @@ class CallDirectoryService {
         processNextChunk()
       } else {
         sharedUserDefaults.setBlockerActionState("finish")
-        sharedUserDefaults.setBlocklistVersion(
-          AppConstants.currentBlocklistVersion
-        )
         UIApplication.shared.isIdleTimerDisabled = false
         onCompletion(true)
       }


### PR DESCRIPTION
This pull request updates the `CallDirectoryService` to improve how the blocklist version is managed and streamline the code. The most important changes involve moving the `setBlocklistVersion` call to a more appropriate location and ensuring it is not redundantly invoked.

### Updates to blocklist version management:

* [`saracroche/Services/CallDirectoryService.swift`](diffhunk://#diff-ee59474d26afb2ae57403eed9f756052b1586804f98bb7955b956708ee27b726R76-R80): Added a call to `sharedUserDefaults.setBlocklistVersion(AppConstants.currentBlocklistVersion)` earlier in the process, ensuring the blocklist version is set before processing begins.
* [`saracroche/Services/CallDirectoryService.swift`](diffhunk://#diff-ee59474d26afb2ae57403eed9f756052b1586804f98bb7955b956708ee27b726L124-L126): Removed the redundant invocation of `sharedUserDefaults.setBlocklistVersion` in the completion block, as it is now handled earlier.