### PR TITLE
Fix button on report view

### DIFF
--- a/saracroche/ViewModels/ReportViewModel.swift
+++ b/saracroche/ViewModels/ReportViewModel.swift
@@ -4,7 +4,6 @@ import SwiftUI
 @MainActor
 class ReportViewModel: ObservableObject {
   @Published var phoneNumber: String = ""
-  @Published var isLoading: Bool = false
   @Published var showAlert: Bool = false
   @Published var alertMessage: String = ""
   @Published var alertType: AlertType = .info
@@ -24,9 +23,10 @@ class ReportViewModel: ObservableObject {
   private let networkService = NetworkService()
 
   func submitPhoneNumber() async {
-    guard validatePhoneNumber() else { return }
+    // Formater le numéro avant validation
+    phoneNumber = formatPhoneNumber(phoneNumber)
 
-    isLoading = true
+    guard validatePhoneNumber() else { return }
 
     do {
       try await networkService.reportPhoneNumber(phoneNumber)
@@ -34,8 +34,6 @@ class ReportViewModel: ObservableObject {
     } catch {
       handleError(error)
     }
-
-    isLoading = false
   }
 
   private func validatePhoneNumber() -> Bool {

--- a/saracroche/Views/Components/CustomButtonStyle.swift
+++ b/saracroche/Views/Components/CustomButtonStyle.swift
@@ -3,46 +3,34 @@ import SwiftUI
 struct CustomButtonStyle: ButtonStyle {
   let background: Color
   let foreground: Color
-  let isLoading: Bool
 
-  init(background: Color, foreground: Color, isLoading: Bool = false) {
+  init(background: Color, foreground: Color) {
     self.background = background
     self.foreground = foreground
-    self.isLoading = isLoading
   }
 
   func makeBody(configuration: Configuration) -> some View {
     HStack {
-      if isLoading {
-        ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: foreground))
-          .scaleEffect(0.8)
-      } else {
-        configuration.label
-      }
+      configuration.label
     }
     .frame(maxWidth: .infinity)
     .frame(height: 48)
     .background(background)
     .foregroundColor(foreground)
     .font(.body.weight(.bold))
-    .cornerRadius(100)
-    .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
+    .cornerRadius(24)
     .opacity(configuration.isPressed ? 0.8 : 1.0)
-    .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
   }
 }
 
 extension ButtonStyle where Self == CustomButtonStyle {
   static func fullWidth(
     background: Color,
-    foreground: Color,
-    isLoading: Bool = false
+    foreground: Color
   ) -> CustomButtonStyle {
     return CustomButtonStyle(
       background: background,
-      foreground: foreground,
-      isLoading: isLoading
+      foreground: foreground
     )
   }
 }

--- a/saracroche/Views/ReportNavigationView.swift
+++ b/saracroche/Views/ReportNavigationView.swift
@@ -6,7 +6,7 @@ struct ReportNavigationView: View {
 
   var body: some View {
     NavigationView {
-      List {
+      Form {
         Section {
           VStack(spacing: 16) {
             Text(
@@ -31,25 +31,13 @@ struct ReportNavigationView: View {
                   )
               )
               .focused($isPhoneFieldFocused)
-              .disabled(viewModel.isLoading)
-              .onChange(of: viewModel.phoneNumber) { newValue in
-                viewModel.phoneNumber = viewModel.formatPhoneNumber(newValue)
-              }
-              .toolbar {
-                ToolbarItemGroup(placement: .keyboard) {
-                  Spacer()
-                  Button("Terminé") {
-                    isPhoneFieldFocused = false
-                  }
-                  .font(.body.weight(.bold))
-                }
-              }
               .accessibilityLabel("Champ de saisie du numéro de téléphone")
               .accessibilityHint(
                 "Saisissez le numéro au format E.164, par exemple +33612345678"
               )
 
             Button {
+              if isPhoneFieldFocused { isPhoneFieldFocused = false }
               Task {
                 await viewModel.submitPhoneNumber()
               }
@@ -62,11 +50,9 @@ struct ReportNavigationView: View {
             .buttonStyle(
               .fullWidth(
                 background: Color("AppColor"),
-                foreground: .black,
-                isLoading: viewModel.isLoading
+                foreground: .black
               )
             )
-            .disabled(viewModel.isLoading)
             .accessibilityLabel("Bouton d'envoi du signalement")
           }
           .padding(.vertical, 6)
@@ -80,14 +66,21 @@ struct ReportNavigationView: View {
         }
       }
       .navigationTitle("Signaler")
+      .toolbar {
+        ToolbarItemGroup(placement: .keyboard) {
+          Spacer()
+          Button("Terminé") {
+            isPhoneFieldFocused = false
+          }
+          .font(.body.weight(.bold))
+        }
+      }
       .alert(viewModel.alertType.title, isPresented: $viewModel.showAlert) {
         Button("OK", role: .cancel) {}
       } message: {
         Text(viewModel.alertMessage)
       }
-      .onTapGesture {
-        isPhoneFieldFocused = false
-      }
+
     }
   }
 }


### PR DESCRIPTION
This pull request refactors the phone number reporting UI and logic to simplify state management and improve code clarity. The main change is the removal of the loading state from both the `ReportViewModel` and the button UI, resulting in a more streamlined user experience and cleaner code. Additionally, input formatting responsibilities are shifted to the view model, and keyboard toolbar management is centralized for better maintainability.

**UI and State Management Simplification:**

* Removed the `isLoading` property and related logic from `ReportViewModel`, including disabling UI elements and showing a loading spinner on the button. This reduces complexity and potential UI inconsistencies. [[1]](diffhunk://#diff-89ff05df12f148b835f351235e4d3aa7b190b4020db2fc2e01961b9e9fcd1f03L7) [[2]](diffhunk://#diff-89ff05df12f148b835f351235e4d3aa7b190b4020db2fc2e01961b9e9fcd1f03L27-L38) [[3]](diffhunk://#diff-0aa9d0d24456de6d9dbc5923a5d268cb6ebbdb4b5661a3c7de4fba150e55dae5L6-R33) [[4]](diffhunk://#diff-c2910659eeef365a1f81c0638223a07248db5628c1f0806c99e7a969d14aa45cL34-R40) [[5]](diffhunk://#diff-c2910659eeef365a1f81c0638223a07248db5628c1f0806c99e7a969d14aa45cL65-L69)

**Input Handling Improvements:**

* Phone number formatting is now handled only in the view model during submission, eliminating redundant formatting in the view and ensuring consistent validation. [[1]](diffhunk://#diff-89ff05df12f148b835f351235e4d3aa7b190b4020db2fc2e01961b9e9fcd1f03L27-L38) [[2]](diffhunk://#diff-c2910659eeef365a1f81c0638223a07248db5628c1f0806c99e7a969d14aa45cL34-R40)

**UI Structure and Accessibility Enhancements:**

* Switched from `List` to `Form` for the main input section, providing a more appropriate structure for form-style input.
* Centralized keyboard toolbar logic at the `NavigationView` level, improving maintainability and ensuring consistent keyboard dismissal behavior. [[1]](diffhunk://#diff-c2910659eeef365a1f81c0638223a07248db5628c1f0806c99e7a969d14aa45cL34-R40) [[2]](diffhunk://#diff-c2910659eeef365a1f81c0638223a07248db5628c1f0806c99e7a969d14aa45cR69-R83)