### PR TITLE
Remove French phone number validation from ReportViewModel

### DIFF
--- a/saracroche/ViewModels/ReportViewModel.swift
+++ b/saracroche/ViewModels/ReportViewModel.swift
@@ -55,12 +55,6 @@ class ReportViewModel: ObservableObject {
       return false
     }
 
-    // Validation for French numbers
-    if trimmedNumber.hasPrefix("+33") && trimmedNumber.count != 12 {
-      showError("Les numéros français doivent contenir 12 caractères au total.")
-      return false
-    }
-
     return true
   }
 


### PR DESCRIPTION
This pull request simplifies the phone number validation logic in the `ReportViewModel` class by removing a specific check for French numbers.

Validation logic simplification:

* Removed the validation that enforced French numbers (those starting with `+33`) to have exactly 12 characters, along with its associated error message. (`saracroche/ViewModels/ReportViewModel.swift`)