### PR TITLE
Remove sensitive configuration files and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 .DS_Store
 xcuserdata/
 build/
-
-# Configuration files with sensitive data
-saracroche/Config.swift

--- a/README.md
+++ b/README.md
@@ -33,17 +33,6 @@ You can also try the latest beta version through [TestFlight](https://testflight
 - iOS 15.0+
 - Swift 5.9+
 
-## Configuration
-
-The app requires a configuration file `Config.swift` that contains sensitive information like server URLs. This file is gitignored for security.
-
-1. Copy the example configuration:
-   ```bash
-   cp saracroche/Config.swift.example saracroche/Config.swift
-   ```
-
-2. Edit `Config.swift` with your actual configuration values.
-
 ## Technology Stack
 
 - **Swift** - Primary programming language

--- a/saracroche/Config.swift.example
+++ b/saracroche/Config.swift.example
@@ -1,5 +1,0 @@
-import Foundation
-
-struct Config {
-    static let reportServerURL = "https://your-server.example.com/report"
-}


### PR DESCRIPTION
This pull request removes the configuration setup for sensitive information from the project. The most important changes are the removal of the configuration instructions from the documentation and the deletion of the example configuration file.

**Documentation update:**

* Removed the "Configuration" section from `README.md`, which previously described how to set up the `Config.swift` file for sensitive information such as server URLs.

**Configuration file removal:**

* Deleted the `saracroche/Config.swift.example` file, which contained the example configuration structure for specifying the report server URL.